### PR TITLE
Add randomize JSON feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Auto Requester
 
-一定範囲の間隔で指定のURLへリクエストを自動送信します。<br>
-Goで実装されたシンプルなライブラリです。<br>
-docker imageを利用することですぐに利用可能です。<br>
+一定範囲の間隔で指定の URL へリクエストを自動送信します。<br>
+Go で実装されたシンプルなライブラリです。<br>
+docker image を利用することですぐに利用可能です。<br>
 
 ## Usage
 
-1. compose.ymlにauto-requesterを追加します
+1. compose.yml に auto-requester を追加します
 2. `$ docker compose up auto-requester`
-3. コンテナが起動すると、environmentで指定したURLに対しリクエストの送信を始めます🥳
+3. コンテナが起動すると、environment で指定した URL に対しリクエストの送信を始めます 🥳
 
 ### サーバーの停止
 
-以下のコマンドを使用して、`http://localhost:8080/stop`にGETリクエストを送信し、サーバーを停止します。
+以下のコマンドを使用して、`http://localhost:8080/stop`に GET リクエストを送信し、サーバーを停止します。
 
 ```sh
 curl http://localhost:8080/stop
@@ -20,7 +20,7 @@ curl http://localhost:8080/stop
 
 ### サーバーの再開
 
-以下のコマンドを使用して、`http://localhost:8080/start`にGETリクエストを送信し、サーバーを再開します。
+以下のコマンドを使用して、`http://localhost:8080/start`に GET リクエストを送信し、サーバーを再開します。
 
 ```sh
 curl http://localhost:8080/start
@@ -28,12 +28,12 @@ curl http://localhost:8080/start
 
 ### リクエストボディの設定
 
-Volume mountを用いて`/etc/app/body.json`に送信したいリクエストボディを設定できます。<br>
-GET, DELETEリクエストの場合は送信されません。
+Volume mount を用いて`/etc/app/body.json`に送信したいリクエストボディを設定できます。<br>
+GET, DELETE リクエストの場合は送信されません。
 
 ```yml
-    volumes:
-      - ./path/to/your_body.json:/etc/app/body.json
+volumes:
+  - ./path/to/your_body.json:/etc/app/body.json
 ```
 
 ### compose.yml example
@@ -45,36 +45,47 @@ services:
     volumes:
       - ./body.json:/etc/app/body.json
     ports:
-      - "8080:8080"
+      - '8080:8080'
     environment:
       - INTERVAL_MIN_SEC=4
       - INTERVAL_MAX_SEC=6
       - TARGET_URL=https://httpbin.org/post
       - HTTP_METHOD=POST
       - CONTENT_TYPE=application/json
-      - RANDOM_BODY=true
+      - RANDOMIZE=true
 ```
 
 ### environments
 
-| env         | description                                             | default |
-|-------------------|--------------------------------------------------|-------------|
-| INTERVAL_MIN_SEC  | リクエストを送信する最小の間隔(秒)           | 3           |
-| INTERVAL_MAX_SEC  | リクエストを送信する最大の時間間隔(秒)<br>INTERVAL_MIN_SECとの間のランダムな間隔でリクエストが実行されます。<br>一定間隔にしたい場合、INTERVAL_MIN_SECと同じ値にしてください            | 5           |
-| TARGET_URL        | リクエストの送信先URL                 | http://localhost:3000 |
-| HTTP_METHOD       | リクエストのHTTPメソッド                         | GET        |
-| CONTENT_TYPE      | リクエストに含めるHTTPヘッダー                   | application/json |
-| (TODO)RANDOM_BODY       | リクエストボディのjsonが配列の場合、配列内の要素から1つを毎回ランダムに選択し、リクエストボディとして用います| true        |
+| env              | description                                                                                                                                                                    | default               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- |
+| INTERVAL_MIN_SEC | リクエストを送信する最小の間隔(秒)                                                                                                                                             | 3                     |
+| INTERVAL_MAX_SEC | リクエストを送信する最大の時間間隔(秒)<br>INTERVAL_MIN_SEC との間のランダムな間隔でリクエストが実行されます。<br>一定間隔にしたい場合、INTERVAL_MIN_SEC と同じ値にしてください | 5                     |
+| TARGET_URL       | リクエストの送信先 URL                                                                                                                                                         | http://localhost:3000 |
+| HTTP_METHOD      | リクエストの HTTP メソッド                                                                                                                                                     | GET                   |
+| CONTENT_TYPE     | リクエストに含める HTTP ヘッダー                                                                                                                                               | application/json      |
+| RANDOMIZE        | リクエストボディの json が配列の場合、配列内の要素から 1 つを毎回ランダムに選択し、リクエストボディとして用います                                                              | true                  |
 
 ## Link
 
 - docker hub
   - [https://hub.docker.com/r/ishikawa096/auto-requester](https://hub.docker.com/r/ishikawa096/auto-requester)
 
-## TODO
+## 📝TODO
 
-- RANDOM_BODYの実装
+- JSON 以外のリクエストボディに対応
 - リクエストに認証ヘッダーを追加可能にする
-- 異常系のテストコード追加
+
+<details>
+<summary>✅Completed</summary>
+
+- RANDOM_BODY の実装
 - 自動テスト
-- docker hubへ自動デプロイ
+- 異常系のテストコード追加
+- docker hub へ自動デプロイ
+- http リクエストを送信する
+- 間隔、リクエストボディを指定可能にする
+- スタート/ストップ操作のための API エンドポイント
+- Docker image をアップロード
+
+</details>

--- a/compose.yml
+++ b/compose.yml
@@ -17,3 +17,4 @@ services:
       - TARGET_URL=https://httpbin.org/post
       - HTTP_METHOD=POST
       - CONTENT_TYPE=application/json
+      - RANDOMIZE=true

--- a/scheduler/config_utils.go
+++ b/scheduler/config_utils.go
@@ -1,0 +1,85 @@
+package scheduler
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ishikawa096/auto-requester/utils"
+)
+
+func getRequestBody() []byte {
+	file, err := os.Open("/etc/app/body.json")
+	if err != nil {
+		// if the file does not exist, return nil
+		utils.Logger("Error opening file:", err)
+		return nil
+	}
+	defer file.Close()
+	// read the file content to memory
+	fileContent, err := io.ReadAll(file)
+	if err != nil {
+		utils.Logger("Error reading file:", err)
+		return nil
+	}
+	return fileContent
+}
+
+// Check the RANDOMIZE env and convert it to a boolean value
+func getRandomizeEnv() bool {
+	randomize := false
+	if randomizeStr, exists := os.LookupEnv("RANDOMIZE"); exists {
+		var err error
+		randomize, err = strconv.ParseBool(randomizeStr)
+		if err != nil {
+			utils.Logger("invalid value for RANDOMIZE:", err)
+		}
+	}
+	return randomize
+}
+
+func getConfigs() (int, int, requestOptions) {
+	// default values
+	minSec := 3
+	maxSec := 5
+	url := "http://localhost:3000"
+	method := "GET"
+	contentType := "application/json"
+
+	if val, exists := os.LookupEnv("INTERVAL_MIN_SEC"); exists {
+		if v, err := strconv.Atoi(val); err == nil {
+			minSec = v
+		}
+	}
+	if val, exists := os.LookupEnv("INTERVAL_MAX_SEC"); exists {
+		if v, err := strconv.Atoi(val); err == nil {
+			maxSec = v
+		}
+	}
+	if val, exists := os.LookupEnv("HTTP_METHOD"); exists {
+		method = strings.ToUpper(val)
+	}
+	if val, exists := os.LookupEnv("TARGET_URL"); exists {
+		url = val
+	}
+	if val, exists := os.LookupEnv("CONTENT_TYPE"); exists {
+		contentType = val
+	}
+
+	var requestBody []byte = nil
+	if method == "POST" || method == "PUT" {
+		requestBody = getRequestBody()
+	}
+
+	var randomize = getRandomizeEnv()
+
+	options := requestOptions{
+		method:      method,
+		url:         url,
+		contentType: contentType,
+		body:        requestBody,
+		randomize:   randomize,
+	}
+	return minSec, maxSec, options
+}

--- a/scheduler/config_utils.go
+++ b/scheduler/config_utils.go
@@ -9,8 +9,53 @@ import (
 	"github.com/ishikawa096/auto-requester/utils"
 )
 
+// default env values
+const (
+	defaultMinSec    = 3
+	defaultMaxSec    = 5
+	defaultUrl       = "http://localhost:3000"
+	defaultMethod    = "GET"
+	defaultType      = "application/json"
+	defaultRandomize = true
+	defaultFilePath  = "/etc/app/body.json"
+)
+
+func getStrEnv(envKey string, defaultValue string) string {
+	if value, exists := os.LookupEnv(envKey); exists {
+		return value
+	}
+	return defaultValue
+}
+
+func getIntEnv(envKey string, defaultValue int) int {
+	valueStr, exists := os.LookupEnv(envKey)
+	if !exists {
+		return defaultValue
+	}
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		utils.Logger("⚠️ invalid value for", envKey, err)
+		return defaultValue
+	}
+	return value
+}
+
+func getBoolEnv(envKey string, defaultValue bool) bool {
+	valueStr, exists := os.LookupEnv(envKey)
+	if !exists {
+		return defaultValue
+	}
+	value, err := strconv.ParseBool(valueStr)
+	if err != nil {
+		utils.Logger("⚠️ invalid value for", envKey, err)
+		return defaultValue
+	}
+	return value
+}
+
+// Reads the JSON file and returns its content as a byte slice.
 func getRequestBody() []byte {
-	file, err := os.Open("/etc/app/body.json")
+	file, err := os.Open(defaultFilePath)
 	if err != nil {
 		// if the file does not exist, return nil
 		utils.Logger("Error opening file:", err)
@@ -26,53 +71,18 @@ func getRequestBody() []byte {
 	return fileContent
 }
 
-// Check the RANDOMIZE env and convert it to a boolean value
-func getRandomizeEnv() bool {
-	randomize := false
-	if randomizeStr, exists := os.LookupEnv("RANDOMIZE"); exists {
-		var err error
-		randomize, err = strconv.ParseBool(randomizeStr)
-		if err != nil {
-			utils.Logger("invalid value for RANDOMIZE:", err)
-		}
-	}
-	return randomize
-}
-
 func getConfigs() (int, int, requestOptions) {
-	// default values
-	minSec := 3
-	maxSec := 5
-	url := "http://localhost:3000"
-	method := "GET"
-	contentType := "application/json"
-
-	if val, exists := os.LookupEnv("INTERVAL_MIN_SEC"); exists {
-		if v, err := strconv.Atoi(val); err == nil {
-			minSec = v
-		}
-	}
-	if val, exists := os.LookupEnv("INTERVAL_MAX_SEC"); exists {
-		if v, err := strconv.Atoi(val); err == nil {
-			maxSec = v
-		}
-	}
-	if val, exists := os.LookupEnv("HTTP_METHOD"); exists {
-		method = strings.ToUpper(val)
-	}
-	if val, exists := os.LookupEnv("TARGET_URL"); exists {
-		url = val
-	}
-	if val, exists := os.LookupEnv("CONTENT_TYPE"); exists {
-		contentType = val
-	}
+	minSec := getIntEnv("INTERVAL_MIN_SEC", defaultMinSec)
+	maxSec := getIntEnv("INTERVAL_MAX_SEC", defaultMaxSec)
+	url := getStrEnv("TARGET_URL", defaultUrl)
+	method := strings.ToUpper(getStrEnv("HTTP_METHOD", defaultMethod))
+	contentType := getStrEnv("CONTENT_TYPE", defaultType)
+	randomize := getBoolEnv("RANDOMIZE", defaultRandomize)
 
 	var requestBody []byte = nil
 	if method == "POST" || method == "PUT" {
 		requestBody = getRequestBody()
 	}
-
-	var randomize = getRandomizeEnv()
 
 	options := requestOptions{
 		method:      method,

--- a/scheduler/config_utils_test.go
+++ b/scheduler/config_utils_test.go
@@ -1,0 +1,153 @@
+package scheduler
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetStrEnv(t *testing.T) {
+	tests := []struct {
+		name         string
+		envKey       string
+		envValue     string
+		defaultValue string
+		expected     string
+	}{
+		{
+			name:         "Environment variable is valid",
+			envKey:       "TEST_STR_ENV",
+			envValue:     "test",
+			defaultValue: "default",
+			expected:     "test",
+		},
+		{
+			name:         "Environment variable is empty",
+			envKey:       "TEST_STR_ENV",
+			envValue:     "",
+			defaultValue: "default",
+			expected:     "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv(tt.envKey, tt.envValue)
+			} else {
+				os.Unsetenv(tt.envKey)
+			}
+
+			result := getStrEnv(tt.envKey, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("getStrEnv(%s, %s) = %s; want %s", tt.envKey, tt.defaultValue, result, tt.expected)
+			}
+
+			os.Unsetenv(tt.envKey)
+		})
+	}
+}
+
+func TestGetIntEnv(t *testing.T) {
+	tests := []struct {
+		name         string
+		envKey       string
+		envValue     string
+		defaultValue int
+		expected     int
+	}{
+		{
+			name:         "Environment variable is valid",
+			envKey:       "TEST_INT_ENV",
+			envValue:     "100",
+			defaultValue: 0,
+			expected:     100,
+		},
+		{
+			name:         "Environment variable is invalid",
+			envKey:       "TEST_INT_ENV",
+			envValue:     "invalid",
+			defaultValue: 0,
+			expected:     0,
+		},
+		{
+			name:         "Environment variable is not set",
+			envKey:       "TEST_INT_ENV",
+			envValue:     "",
+			defaultValue: 100,
+			expected:     100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv(tt.envKey, tt.envValue)
+			} else {
+				os.Unsetenv(tt.envKey)
+			}
+
+			result := getIntEnv(tt.envKey, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("getIntEnv(%s, %v) = %v; want %v", tt.envKey, tt.defaultValue, result, tt.expected)
+			}
+
+			os.Unsetenv(tt.envKey)
+		})
+	}
+}
+
+func TestGetBoolEnv(t *testing.T) {
+	tests := []struct {
+		name         string
+		envKey       string
+		envValue     string
+		defaultValue bool
+		expected     bool
+	}{
+		{
+			name:         "Environment variable is true",
+			envKey:       "TEST_BOOL_ENV",
+			envValue:     "true",
+			defaultValue: false,
+			expected:     true,
+		},
+		{
+			name:         "Environment variable is false",
+			envKey:       "TEST_BOOL_ENV",
+			envValue:     "false",
+			defaultValue: true,
+			expected:     false,
+		},
+		{
+			name:         "Environment variable is invalid",
+			envKey:       "TEST_BOOL_ENV",
+			envValue:     "invalid",
+			defaultValue: true,
+			expected:     true,
+		},
+		{
+			name:         "Environment variable is not set",
+			envKey:       "TEST_BOOL_ENV",
+			envValue:     "",
+			defaultValue: true,
+			expected:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				os.Setenv(tt.envKey, tt.envValue)
+			} else {
+				os.Unsetenv(tt.envKey)
+			}
+
+			result := getBoolEnv(tt.envKey, tt.defaultValue)
+			if result != tt.expected {
+				t.Errorf("getBoolEnv(%s, %v) = %v; want %v", tt.envKey, tt.defaultValue, result, tt.expected)
+			}
+
+			os.Unsetenv(tt.envKey)
+		})
+	}
+}

--- a/scheduler/json_utils.go
+++ b/scheduler/json_utils.go
@@ -1,0 +1,28 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/ishikawa096/auto-requester/utils"
+	"golang.org/x/exp/rand"
+)
+
+// IF the body is a JSON array, select a random element from it.
+// Otherwise, return the body as is.
+func selectRandomElement(body []byte) []byte {
+	var jsonArray []interface{}
+	if err := json.Unmarshal(body, &jsonArray); err == nil {
+		if len(jsonArray) > 0 {
+			rand.Seed(uint64(time.Now().UnixNano()))
+			randomIndex := rand.Intn(len(jsonArray))
+			randomElement, err := json.Marshal(jsonArray[randomIndex])
+			if err != nil {
+				utils.Logger("failed to marshal random element: %v", err)
+				return body
+			}
+			return randomElement
+		}
+	}
+	return body
+}

--- a/scheduler/json_utils_test.go
+++ b/scheduler/json_utils_test.go
@@ -1,0 +1,71 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestSelectRandomElement(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     []byte
+		expected []byte
+	}{
+		{
+			name:     "Valid JSON",
+			body:     []byte(`{"name":"apple","children":[{"name":"banana"},{"name":"cherry"}]}`),
+			expected: []byte(`{"name":"apple","children":[{"name":"banana"},{"name":"cherry"}]}`),
+		},
+		{
+			name:     "Valid JSON array",
+			body:     []byte(`[{"name":"apple"},{"name":"banana"},{"name":"cherry"}]`),
+			expected: nil, // We can't predict the exact output, so we will check if it's one of the elements
+		},
+		{
+			name:     "Empty JSON array",
+			body:     []byte(`[]`),
+			expected: []byte(`[]`),
+		},
+		{
+			name:     "Invalid JSON",
+			body:     []byte(`invalid json`),
+			expected: []byte(`invalid json`),
+		},
+		{
+			name:     "Nil",
+			body:     nil,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectRandomElement(tt.body)
+
+			if tt.expected == nil && tt.body != nil {
+				// Check if the result is one of the elements in the original array
+				var jsonArray []interface{}
+				if err := json.Unmarshal(tt.body, &jsonArray); err == nil {
+					found := false
+					for _, elem := range jsonArray {
+						elemBytes, _ := json.Marshal(elem)
+						if reflect.DeepEqual(got, elemBytes) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("selectRandomElement() = %s, want one of %s", got, tt.body)
+					}
+				}
+				return
+			}
+
+			// IF the expected result is not nil, we can compare the results
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("selectRandomElement() = %s, want %s", got, tt.expected)
+			}
+		})
+	}
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -5,19 +5,18 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
 	"github.com/ishikawa096/auto-requester/utils"
 )
 
-type httpOptions struct {
+type requestOptions struct {
 	method      string // GET, POST, PUT, DELETE
 	url         string
 	contentType string
 	body        []byte
+	randomize   bool
 }
 
 var Scheduler gocron.Scheduler
@@ -32,9 +31,16 @@ func init() {
 	}
 }
 
-func sendRequest(options httpOptions) (*http.Response, error) {
-	// リクエストボディを再利用可能な形にするために、bytes.Readerを使用
-	bodyReader := bytes.NewReader(options.body)
+func sendRequest(options requestOptions) (*http.Response, error) {
+	var requestBody []byte = nil
+	if options.randomize {
+		requestBody = selectRandomElement(options.body)
+	} else {
+		requestBody = options.body
+	}
+
+	// To use the request body multiple times, we need to create a reader
+	bodyReader := bytes.NewReader(requestBody)
 
 	req, err := http.NewRequest(options.method, options.url, bodyReader)
 	if err != nil {
@@ -51,9 +57,9 @@ func sendRequest(options httpOptions) (*http.Response, error) {
 	return resp, nil
 }
 
-func createTask(options httpOptions) gocron.Task {
+func createTask(options requestOptions) gocron.Task {
 	return gocron.NewTask(
-		func(options httpOptions) {
+		func(options requestOptions) {
 			resp, err := sendRequest(options)
 			if err != nil {
 				utils.Logger("Error sending request:", err)
@@ -72,7 +78,7 @@ func createTask(options httpOptions) gocron.Task {
 	)
 }
 
-func registerJob(minSec, maxSec int, options httpOptions) {
+func registerJob(minSec, maxSec int, options requestOptions) {
 	_, err := Scheduler.NewJob(
 		gocron.DurationRandomJob(
 			time.Duration(minSec)*time.Second,
@@ -86,66 +92,8 @@ func registerJob(minSec, maxSec int, options httpOptions) {
 	}
 }
 
-func getRequestBody() []byte {
-	file, err := os.Open("/etc/app/body.json")
-	if err != nil {
-		utils.Logger("Error opening file:", err)
-		os.Exit(1)
-	}
-	defer file.Close()
-	// read the file content to memory
-	fileContent, err := io.ReadAll(file)
-	if err != nil {
-		utils.Logger("Error reading file:", err)
-		os.Exit(1)
-	}
-	return fileContent
-}
-
-func getSettingValues() (int, int, httpOptions) {
-	// default values
-	minSec := 3
-	maxSec := 5
-	url := "http://localhost:3000"
-	method := "GET"
-	contentType := "application/json"
-
-	if val, exists := os.LookupEnv("INTERVAL_MIN_SEC"); exists {
-		if v, err := strconv.Atoi(val); err == nil {
-			minSec = v
-		}
-	}
-	if val, exists := os.LookupEnv("INTERVAL_MAX_SEC"); exists {
-		if v, err := strconv.Atoi(val); err == nil {
-			maxSec = v
-		}
-	}
-	if val, exists := os.LookupEnv("HTTP_METHOD"); exists {
-		method = strings.ToUpper(val)
-	}
-	if val, exists := os.LookupEnv("TARGET_URL"); exists {
-		url = val
-	}
-	if val, exists := os.LookupEnv("CONTENT_TYPE"); exists {
-		contentType = val
-	}
-
-	var requestBody []byte = nil
-	if method == "POST" || method == "PUT" {
-		requestBody = getRequestBody()
-	}
-
-	options := httpOptions{
-		method:      method,
-		url:         url,
-		contentType: contentType,
-		body:        requestBody,
-	}
-	return minSec, maxSec, options
-}
-
 func StartJob() {
-	registerJob(getSettingValues())
+	registerJob(getConfigs())
 
 	// start the scheduler
 	Scheduler.Start()


### PR DESCRIPTION
## 概要
JSONが配列の場合に中の要素をランダムに選択して送信する機能の実装。
環境変数でON/OFF切り替え可能。

## 変更内容

- RANDOMIZE環境変数のサポート
- selectRandomElement関数の実装
- schedulerパッケージの整理

## 動作確認
productionビルドで確認
httpメソッド: GET, POST, PUT, DELETE
RANDOMIZE: true, false

### JSON が配列

#### RANDOMIZE: true

- [ ] POST, PUT
      → 配列の 1 要素がランダムでリクエストボディとして送信されること
- [ ] GET, DELETE
      → リクエストボディが送信されないこと

#### RANDOMIZE: false

- [ ] POST, PUT
      → リクエストボディがそのまま送信されること
- [ ] GET, DELETE
      → リクエストボディが送信されないこと

### JSON が単数

#### RANDOMIZE: true

- [ ] POST, PUT
      → リクエストボディがそのまま送信されること
- [ ] GET, DELETE
      → リクエストボディが送信されないこと

#### RANDOMIZE: false

- [ ] POST, PUT
      → リクエストボディがそのまま送信されること
- [ ] GET, DELETE
      → リクエストボディが送信されないこと

### JSON ではない文字列

#### RANDOMIZE: true

- [ ] POST, PUT
      → リクエストボディがそのまま送信されること
- [ ] GET, DELETE
      → リクエストボディが送信されないこと

#### RANDOMIZE: false

- [ ] POST, PUT
      → リクエストボディがそのまま送信されること
- [ ] GET, DELETE
      → リクエストボディが送信されないこと

## 関連Issue

- 

## その他

- 
